### PR TITLE
Handle reserved Windows filenames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,3 @@ language: node_js
 node_js:
   - '5'
   - '4'
-  - '0.12'
-  - '0.10'

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var stripOuter = require('strip-outer');
 // doesn't make sense to have longer filenames
 var MAX_FILENAME_LENGTH = 100;
 
+/* eslint no-control-regex: "off" */
 var reControlChars = /[\x00-\x1f\x80-\x9f]/g;
 var reRelativePath = /^\.+/;
 
@@ -32,6 +33,7 @@ var fn = module.exports = function (str, opts) {
 		str = str.length > 1 ? stripOuter(str, replacement) : str;
 	}
 
+	str = str.match(filenameReservedRegex.windowsNames()) ? replacement : str;
 	str = str.slice(0, MAX_FILENAME_LENGTH);
 
 	return str;

--- a/index.js
+++ b/index.js
@@ -7,8 +7,7 @@ var stripOuter = require('strip-outer');
 // doesn't make sense to have longer filenames
 var MAX_FILENAME_LENGTH = 100;
 
-/* eslint no-control-regex: "off" */
-var reControlChars = /[\x00-\x1f\x80-\x9f]/g;
+var reControlChars = /[\x00-\x1f\x80-\x9f]/g; // eslint-disable-line no-control-regex
 var reRelativePath = /^\.+/;
 
 var fn = module.exports = function (str, opts) {

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var fn = module.exports = function (str, opts) {
 		str = str.length > 1 ? stripOuter(str, replacement) : str;
 	}
 
-	str = str.match(filenameReservedRegex.windowsNames()) ? replacement : str;
+	str = filenameReservedRegex.windowsNames().test(str) ? replacement : str;
 	str = str.slice(0, MAX_FILENAME_LENGTH);
 
 	return str;

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var fn = module.exports = function (str, opts) {
 		str = str.length > 1 ? stripOuter(str, replacement) : str;
 	}
 
-	str = filenameReservedRegex.windowsNames().test(str) ? replacement : str;
+	str = filenameReservedRegex.windowsNames().test(str) ? str + replacement : str;
 	str = str.slice(0, MAX_FILENAME_LENGTH);
 
 	return str;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "dirname"
   ],
   "dependencies": {
-    "filename-reserved-regex": "^1.0.0",
+    "filename-reserved-regex": "^2.0.0",
     "strip-outer": "^1.0.0",
     "trim-repeated": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4"
   },
   "scripts": {
     "test": "xo && ava"

--- a/test.js
+++ b/test.js
@@ -14,10 +14,10 @@ test('filnamify()', t => {
 	t.is(m('..'), '!');
 	t.is(m('./'), '!');
 	t.is(m('../'), '!');
-	t.is(m('con'), '!');
+	t.is(m('con'), 'con!');
 	t.is(m('foo/bar/nul'), 'foo!bar!nul');
-	t.is(m('con', {replacement: '🐴🐴'}), '🐴🐴');
-	t.is(m('c/n', {replacement: 'o'}), 'o');
+	t.is(m('con', {replacement: '🐴🐴'}), 'con🐴🐴');
+	t.is(m('c/n', {replacement: 'o'}), 'cono');
 	t.is(m('c/n', {replacement: 'con'}), 'cconn');
 });
 

--- a/test.js
+++ b/test.js
@@ -14,6 +14,11 @@ test('filnamify()', t => {
 	t.is(m('..'), '!');
 	t.is(m('./'), '!');
 	t.is(m('../'), '!');
+	t.is(m('con'), '!');
+	t.is(m('foo/bar/nul'), 'foo!bar!nul');
+	t.is(m('con', {replacement: '🐴🐴'}), '🐴🐴');
+	t.is(m('c/n', {replacement: 'o'}), 'o');
+	t.is(m('c/n', {replacement: 'con'}), 'cconn');
 });
 
 test('filenamify.path()', t => {


### PR DESCRIPTION
The **filename-reserved-regex** version as been changed on _package.json_ in order to be able to provide the `windowsNames` regex. 
The flag `no-control-regex` on ESLint was blocking tests to run smoothly. After analysing the ESLint documentation, this rule has to be disabled in order to manipulate control characters in regular expressions. Additional unit test were added, to make use of the new feature.

---

Fixes #1