### PR TITLE
Allow using empty string as a replacement

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const fn = (string, options) => {
 
 	options = options || {};
 
-	const replacement = options.replacement || '!';
+	const replacement = opts.replacement === undefined ? '!' : opts.replacement;
 
 	if (filenameReservedRegex().test(replacement) && reControlChars.test(replacement)) {
 		throw new Error('Replacement string cannot contain reserved filename characters');


### PR DESCRIPTION
I want to use an empty string as a replacement to able to remove junky symbols completely. Like this: 

```javascript
filenamify(UNSAFE_USER_INPUT, {replacement: ''})
```
Now I can't do this because of Javascript type conversion in this statement: `options.replacement || '!';` This PR fixes that issue.