### PR TITLE
Prevent overwriting replacement character in the original string

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const filenameReservedRegex = require('filename-reserved-regex');
 // Doesn't make sense to have longer filenames
 const MAX_FILENAME_LENGTH = 100;
 
+const reRepeatedReservedChars = /([<>:"/\\|?*\x00-\x1F]){2,}/g; // eslint-disable-line no-control-regex, unicorn/no-hex-escape
+const reOuterReservedChars = /^[<>:"/\\|?*\x00-\x1F]|[<>:"/\\|?*\x00-\x1F]$/g; // eslint-disable-line no-control-regex, unicorn/no-hex-escape
 const reControlChars = /[\u0000-\u001f\u0080-\u009f]/g; // eslint-disable-line no-control-regex
 const reRelativePath = /^\.+/;
 
@@ -39,8 +41,8 @@ filenamify.path = (filePath, options) => {
 	return path.join(path.dirname(filePath), filenamify(path.basename(filePath), options));
 };
 
-const trimRepeatedReservedChars = str => str.replace(/([<>:"/\\|?*\x00-\x1F]){2,}/g, '$1'); // eslint-disable-line no-control-regex, unicorn/no-hex-escape
+const trimRepeatedReservedChars = str => str.replace(reRepeatedReservedChars, '$1');
 
-const stripOuterReservedChars = str => str.replace(/^[<>:"/\\|?*\x00-\x1F]|[<>:"/\\|?*\x00-\x1F]$/g, ''); // eslint-disable-line no-control-regex, unicorn/no-hex-escape
+const stripOuterReservedChars = str => str.replace(reOuterReservedChars, '');
 
 module.exports = filenamify;

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
 		"dirname"
 	],
 	"dependencies": {
-		"filename-reserved-regex": "^2.0.0",
-		"strip-outer": "^1.0.1",
-		"trim-repeated": "^1.0.0"
+		"filename-reserved-regex": "^2.0.0"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",

--- a/test.js
+++ b/test.js
@@ -19,6 +19,9 @@ test('filnamify()', t => {
 	t.is(filenamify('con', {replacement: '🐴🐴'}), 'con🐴🐴');
 	t.is(filenamify('c/n', {replacement: 'o'}), 'cono');
 	t.is(filenamify('c/n', {replacement: 'con'}), 'cconn');
+	t.is(filenamify('my <file name-', {replacement: '-'}), 'my -file name-');
+	t.is(filenamify('--<abc->>>--', {replacement: '-'}), '---abc----');
+	t.is(filenamify('-<<abc>-', {replacement: '-'}), '--abc--');
 });
 
 test('filenamify.path()', t => {


### PR DESCRIPTION
Fixes #11. Now we trim repeat and outer reserved chars **before** doing a global replace with the replacement char, to preserve instances of that char present in the original string. IMO the other two cases mentioned there are handled correctly as is, since I take the purpose of the library as preserving as much of the original string as possible without redundancy.

Sidenote: I think the multiple similar regex definitions here could be simplified with ES6 string literals, but the linter barks at that.