### PR TITLE
Add option to avoid removing repeated replacement

### DIFF
--- a/filenamify.d.ts
+++ b/filenamify.d.ts
@@ -39,11 +39,11 @@ filenamify('<foo/bar>');
 
 filenamify('foo:"bar"', {replacement: '🐴'});
 //=> 'foo🐴bar'
+
+filenamify('/path/to/file---name.ext"', {replacement: '-', condenseReplacements: true});
+//=> 'path-to-file---name.ext'
 ```
 */
-declare const filenamify: (
-	string: string,
-	options?: filenamify.Options
-) => string;
+declare const filenamify: (string: string, options?: filenamify.Options) => string;
 
 export = filenamify;

--- a/filenamify.d.ts
+++ b/filenamify.d.ts
@@ -17,6 +17,13 @@ declare namespace filenamify {
 		@default 100
 		*/
 		readonly maxLength?: number;
+
+		/**
+		Preserve the repeated replacements of a given string.
+
+		@default false
+		*/
+		readonly condenseReplacements?: boolean;
 	}
 }
 
@@ -34,6 +41,9 @@ filenamify('foo:"bar"', {replacement: '🐴'});
 //=> 'foo🐴bar'
 ```
 */
-declare const filenamify: (string: string, options?: filenamify.Options) => string;
+declare const filenamify: (
+	string: string,
+	options?: filenamify.Options
+) => string;
 
 export = filenamify;

--- a/filenamify.js
+++ b/filenamify.js
@@ -15,6 +15,7 @@ const filenamify = (string, options = {}) => {
 	}
 
 	const replacement = options.replacement === undefined ? '!' : options.replacement;
+	const condenseReplacements = options.condenseReplacements === undefined ? false : options.condenseReplacements;
 
 	if (filenameReservedRegex().test(replacement) && reControlChars.test(replacement)) {
 		throw new Error('Replacement string cannot contain reserved filename characters');
@@ -25,7 +26,10 @@ const filenamify = (string, options = {}) => {
 	string = string.replace(reRelativePath, replacement);
 
 	if (replacement.length > 0) {
-		string = trimRepeated(string, replacement);
+		if (!condenseReplacements) {
+			string = trimRepeated(string, replacement);
+		}
+
 		string = string.length > 1 ? stripOuter(string, replacement) : string;
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,9 @@ filenamify('<foo/bar>');
 
 filenamify('foo:"bar"', {replacement: '🐴'});
 //=> 'foo🐴bar'
+
+filenamify('/foo/to/bar---file.txt"', {replacement: '-', condenseReplacements: true});
+//=> 'foo-to-bar---file.txt'
 ```
 
 ## API

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,13 @@ String to use as replacement for reserved filename characters.
 
 Cannot contain: `<` `>` `:` `"` `/` `\` `|` `?` `*`
 
+### condenseReplacements
+
+Type: `boolean`\
+Default: `false`
+
+Preserves the repeated replacements of a given string.
+
 ##### maxLength
 
 Type: `number`\

--- a/test.js
+++ b/test.js
@@ -19,6 +19,7 @@ test('filnamify()', t => {
 	t.is(filenamify('con', {replacement: '🐴🐴'}), 'con🐴🐴');
 	t.is(filenamify('c/n', {replacement: 'o'}), 'cono');
 	t.is(filenamify('c/n', {replacement: 'con'}), 'cconn');
+	t.is(filenamify('/path/to/file---name.ext', {replacement: '-', condenseReplacements: true}), 'path-to-file---name.ext');
 });
 
 test('filenamify.path()', t => {


### PR DESCRIPTION
Feature of avoid removing repeated replacement added suggested by the issue #10.

A new option is now available named `'condenseReplacements'` as suggested by @sindresorhus on issue #10 

```js
filenamify('/path/to/file---name.ext"', {replacement: '-', condenseReplacements: true});
// => path-to-file---name.ext
```
Test case added along with updated `README`

// @sindresorhus 

Fixes #10