### PR TITLE
Remove trailing periods for consistency on Windows

### DIFF
--- a/filenamify.js
+++ b/filenamify.js
@@ -8,6 +8,7 @@ const MAX_FILENAME_LENGTH = 100;
 
 const reControlChars = /[\u0000-\u001f\u0080-\u009f]/g; // eslint-disable-line no-control-regex
 const reRelativePath = /^\.+/;
+const reTrailingPeriods = /\.+$/;
 
 const filenamify = (string, options = {}) => {
 	if (typeof string !== 'string') {
@@ -23,6 +24,7 @@ const filenamify = (string, options = {}) => {
 	string = string.replace(filenameReservedRegex(), replacement);
 	string = string.replace(reControlChars, replacement);
 	string = string.replace(reRelativePath, replacement);
+	string = string.replace(reTrailingPeriods, '');
 
 	if (replacement.length > 0) {
 		string = trimRepeated(string, replacement);

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Convert a string to a valid safe filename
 
-On Unix-like systems `/` is reserved and [`<>:"/\|?*`](http://msdn.microsoft.com/en-us/library/aa365247%28VS.85%29#naming_conventions) on Windows.
+On Unix-like systems `/` is reserved. On Windows, [`<>:"/\|?*`](http://msdn.microsoft.com/en-us/library/aa365247%28VS.85%29#naming_conventions) along with trailing periods are reserved.
 
 ## Install
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Convert a string to a valid safe filename
 
-On Unix-like systems `/` is reserved. On Windows, [`<>:"/\|?*`](http://msdn.microsoft.com/en-us/library/aa365247%28VS.85%29#naming_conventions) along with trailing periods are reserved.
+On Unix-like systems, `/` is reserved. On Windows, [`<>:"/\|?*`](http://msdn.microsoft.com/en-us/library/aa365247%28VS.85%29#naming_conventions) along with trailing periods are reserved.
 
 ## Install
 

--- a/test.js
+++ b/test.js
@@ -14,6 +14,9 @@ test('filnamify()', t => {
 	t.is(filenamify('..'), '!');
 	t.is(filenamify('./'), '!');
 	t.is(filenamify('../'), '!');
+	t.is(filenamify('foo.bar.'), 'foo.bar');
+	t.is(filenamify('foo.bar..'), 'foo.bar');
+	t.is(filenamify('foo.bar...'), 'foo.bar');
 	t.is(filenamify('con'), 'con!');
 	t.is(filenamify('foo/bar/nul'), 'foo!bar!nul');
 	t.is(filenamify('con', {replacement: '🐴🐴'}), 'con🐴🐴');


### PR DESCRIPTION
Replace trailing periods to allow for consistency with Windows. (https://superuser.com/a/585119/974653)

Examples:

- `he.llo` -> `he.llo`
- `hell.o.` -> `hell.o`
- `hello....` -> `hello`