### PR TITLE
Fix filenames truncated by `maxLength` not keeping their extension

### DIFF
--- a/filenamify.js
+++ b/filenamify.js
@@ -31,7 +31,11 @@ export default function filenamify(string, options = {}) {
 	}
 
 	string = filenameReservedRegex.windowsNames().test(string) ? string + replacement : string;
-	string = string.slice(0, typeof options.maxLength === 'number' ? options.maxLength : MAX_FILENAME_LENGTH);
+	const allowedLength = typeof options.maxLength === 'number' ? options.maxLength : MAX_FILENAME_LENGTH;
+	if (allowedLength < string.length) {
+		const extensionIndex = string.lastIndexOf('.');
+		string = string.slice(0, Math.min(allowedLength, extensionIndex)) + string.slice(extensionIndex);
+	}
 
 	return string;
 }

--- a/filenamify.js
+++ b/filenamify.js
@@ -32,7 +32,7 @@ export default function filenamify(string, options = {}) {
 
 	string = filenameReservedRegex.windowsNames().test(string) ? string + replacement : string;
 	const allowedLength = typeof options.maxLength === 'number' ? options.maxLength : MAX_FILENAME_LENGTH;
-	if (allowedLength < string.length) {
+	if (string.length > allowedLength) {
 		const extensionIndex = string.lastIndexOf('.');
 		string = string.slice(0, Math.min(allowedLength, extensionIndex)) + string.slice(extensionIndex);
 	}

--- a/test.js
+++ b/test.js
@@ -29,11 +29,13 @@ test('filnamify()', t => {
 
 test('filenamifyPath()', t => {
 	t.is(path.basename(filenamifyPath(path.join(directoryName, 'foo:bar'))), 'foo!bar');
+	t.is(path.basename(filenamifyPath(path.join(directoryName, 'This? This is very long filename that will lose its extension when passed into filenamify, which could cause issues.csv'))),
+		'This! This is very long filename that will lose its extension when passed into filenamify, which cou.csv');
 });
 
 test('filenamify length', t => {
 	// Basename length: 152
 	const filename = 'this/is/a/very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_filename.txt';
-	t.is(filenamify(path.basename(filename)), 'very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_');
+	t.is(filenamify(path.basename(filename)), 'very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_.txt');
 	t.is(filenamify(path.basename(filename), {maxLength: 180}), 'very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_filename.txt');
 });


### PR DESCRIPTION
Fixes #13 

Excludes the extension, truncates the string to the required length, appends the extension.

Example - 
**Input :** very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_filename.txt

**Output**
very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_.txt