### PR TITLE
Fix maxLength broken on files with no extension

### DIFF
--- a/filenamify.js
+++ b/filenamify.js
@@ -35,7 +35,9 @@ export default function filenamify(string, options = {}) {
 	const allowedLength = typeof options.maxLength === 'number' ? options.maxLength : MAX_FILENAME_LENGTH;
 	if (string.length > allowedLength) {
 		const extensionIndex = string.lastIndexOf('.');
-		string = string.slice(0, Math.min(allowedLength, extensionIndex)) + string.slice(extensionIndex);
+		const filename = extensionIndex > -1 ? string.slice(0, extensionIndex) : string;
+		const extension = extensionIndex > -1 ? string.slice(extensionIndex) : '';
+		string = filename.slice(0, Math.min(allowedLength, filename.length)) + extension;
 	}
 
 	return string;

--- a/filenamify.js
+++ b/filenamify.js
@@ -35,8 +35,8 @@ export default function filenamify(string, options = {}) {
 	const allowedLength = typeof options.maxLength === 'number' ? options.maxLength : MAX_FILENAME_LENGTH;
 	if (string.length > allowedLength) {
 		const extensionIndex = string.lastIndexOf('.');
-		const filename = extensionIndex > -1 ? string.slice(0, extensionIndex) : string;
-		const extension = extensionIndex > -1 ? string.slice(extensionIndex) : '';
+		const filename = extensionIndex === -1 ? string : string.slice(0, extensionIndex);
+		const extension = extensionIndex === -1 ? '' : string.slice(extensionIndex);
 		string = filename.slice(0, Math.min(allowedLength, filename.length)) + extension;
 	}
 

--- a/test.js
+++ b/test.js
@@ -38,4 +38,9 @@ test('filenamify length', t => {
 	const filename = 'this/is/a/very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_filename.txt';
 	t.is(filenamify(path.basename(filename)), 'very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_.txt');
 	t.is(filenamify(path.basename(filename), {maxLength: 180}), 'very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_filename.txt');
+
+	// Basename length: 148
+	const filenameNoExt = 'very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_filename';
+	t.is(filenamify(filenameNoExt), 'very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_');
+	t.is(filenamify(filenameNoExt, {maxLength: 20}), 'very_very_very_very_');
 });


### PR DESCRIPTION
Currently, files with no extension are not accounted for when satisfying `maxLength`, which results in them not being trimmed at all (accident of `lastIndexOf()` returning `-1`).

This PR fixes it.

BUT! There is another thing which I personally consider an issue. Currently, `maxLength` trims only the filename part to the desired length, and then attaches the extension. I haven't changed this behavior in this PR, but I personally don't consider it right. If I want a filename to be 100 chars long, then it should be 100 chars long including the extension, not 100 chars + extension length.

Should I fix this too? And if so, what would be the behavior if it can't be satisfied due to the extension itself being longer than the `maxLength` requirement?

The options are:
- We just trim the whole filename from the end as one string, and document extension preservation as a luxury available only for sane inputs. This will break the filename as other apps won't recognize it anymore.
- Leave the extension and document it → doesn't satisfy `maxLength`, breaks something else potentially.
- Throw an error, as the `maxLength` can't be satisfied without breaking something, but this will bite people in the ass, as this is one of those things that tends to happen only in production.