### PR TITLE
Add option to avoid deleting repeated replacement.

### DIFF
--- a/filenamify.d.ts
+++ b/filenamify.d.ts
@@ -18,6 +18,13 @@ export interface Options {
 	@default 100
 	*/
 	readonly maxLength?: number;
+
+	/**
+	Preserve the repeated replacements of a given string.
+
+	@default false
+	*/
+	readonly preserveRepeatedReplacements?: boolean;
 }
 
 /**
@@ -32,6 +39,9 @@ filenamify('<foo/bar>');
 
 filenamify('foo:"bar"', {replacement: '🐴'});
 //=> 'foo🐴bar'
+
+filenamify('/path/to/file---name.ext"', {replacement: '-', condenseReplacements: true});
+//=> 'path-to-file---name.ext'
 ```
 */
 export default function filenamify(string: string, options?: Options): string;

--- a/filenamify.js
+++ b/filenamify.js
@@ -15,6 +15,7 @@ export default function filenamify(string, options = {}) {
 	}
 
 	const replacement = options.replacement === undefined ? '!' : options.replacement;
+	const preserveRepeatedReplacements = options.preserveRepeatedReplacements === undefined ? false : options.preserveRepeatedReplacements;
 
 	if (filenameReservedRegex().test(replacement) && reControlChars.test(replacement)) {
 		throw new Error('Replacement string cannot contain reserved filename characters');
@@ -29,7 +30,10 @@ export default function filenamify(string, options = {}) {
 	if (replacement.length > 0) {
 		const startedWithDot = string[0] === '.';
 
-		string = trimRepeated(string, replacement);
+		if (!preserveRepeatedReplacements) {
+			string = trimRepeated(string, replacement);
+		}
+
 		string = string.length > 1 ? stripOuter(string, replacement) : string;
 
 		// We removed the whole filename

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,15 @@ Only the base of the filename is truncated, preserving the extension. If the ext
 
 Systems generally allow up to 255 characters, but we default to 100 for usability reasons.
 
+##### preserveRepeatedReplacements
+
+Type: `boolean`\
+Default: `false`
+
+If true, does not remove any repetition of the replacement string.
+
+The default behavior is to remove any repetitions of the replacement string, even if they are already present in the original string
+
 ## Browser-only import
 
 You can also import `filenamify/browser`, which only imports `filenamify` and not `filenamifyPath`, which relies on `path` being available or polyfilled. Importing `filenamify` this way is therefore useful when it is shipped using `webpack` or similar tools, and if `filenamifyPath` is not needed.

--- a/test.js
+++ b/test.js
@@ -28,6 +28,7 @@ test('filenamify()', t => {
 	t.is(filenamify('c/n', {replacement: 'o'}), 'cono');
 	t.is(filenamify('c/n', {replacement: 'con'}), 'cconn');
 	t.is(filenamify('.dotfile'), '.dotfile');
+	t.is(filenamify('/path/to/file---name.ext', {replacement: '-'}), 'path-to-file-name.ext');
 });
 
 test('filenamifyPath()', t => {
@@ -50,4 +51,9 @@ test('filenamify length', t => {
 	t.is(filenamify(filenameNoExt), 'very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_');
 	t.is(filenamify(filenameNoExt, {maxLength: 20}), 'very_very_very_very_');
 	t.is(filenamify('.asdfghjkl', {maxLength: 2}), '.asdfghjkl');
+});
+
+test('filenamify condenseReplacements', t => {
+	t.is(filenamify('/path/to/file---name.ext', {replacement: '-', preserveRepeatedReplacements: true}), 'path-to-file---name.ext');
+	t.is(filenamify('/path/to/file---name.ext', {replacement: '-', preserveRepeatedReplacements: false}), 'path-to-file-name.ext');
 });


### PR DESCRIPTION
Add a new option `preserveRepeatedReplacements`. If it's set to true, avoids squashing consecutive occurrences of the replacement string. Defaults to false to preserve current behavior.

Fixes #10 
