### PR TITLE
Prevent stripping of outer replaced characters.

### DIFF
--- a/filenamify.d.ts
+++ b/filenamify.d.ts
@@ -28,10 +28,10 @@ Convert a string to a valid filename.
 import filenamify from 'filenamify';
 
 filenamify('<foo/bar>');
-//=> 'foo!bar'
+//=> '!foo!bar!'
 
 filenamify('foo:"bar"', {replacement: '🐴'});
-//=> 'foo🐴bar'
+//=> 'foo🐴bar🐴'
 ```
 */
 export default function filenamify(string: string, options?: Options): string;

--- a/filenamify.js
+++ b/filenamify.js
@@ -1,10 +1,9 @@
-import trimRepeated from 'trim-repeated';
 import filenameReservedRegex, {windowsReservedNameRegex} from 'filename-reserved-regex';
-import stripOuter from 'strip-outer';
 
 // Doesn't make sense to have longer filenames
 const MAX_FILENAME_LENGTH = 100;
 
+const reRepeatedReservedChars = /([<>:"/\\|?*\u0000-\u001F]){2,}/g; // eslint-disable-line no-control-regex
 const reControlChars = /[\u0000-\u001F\u0080-\u009F]/g; // eslint-disable-line no-control-regex
 const reRelativePath = /^\.+(\\|\/)|^\.+$/;
 const reTrailingPeriods = /\.+$/;
@@ -20,6 +19,10 @@ export default function filenamify(string, options = {}) {
 		throw new Error('Replacement string cannot contain reserved filename characters');
 	}
 
+	if (replacement.length > 0) {
+		string = trimRepeatedReservedChars(string);
+	}
+
 	string = string.normalize('NFD');
 	string = string.replace(reRelativePath, replacement);
 	string = string.replace(filenameReservedRegex(), replacement);
@@ -28,9 +31,6 @@ export default function filenamify(string, options = {}) {
 
 	if (replacement.length > 0) {
 		const startedWithDot = string[0] === '.';
-
-		string = trimRepeated(string, replacement);
-		string = string.length > 1 ? stripOuter(string, replacement) : string;
 
 		// We removed the whole filename
 		if (!startedWithDot && string[0] === '.') {
@@ -58,3 +58,5 @@ export default function filenamify(string, options = {}) {
 
 	return string;
 }
+
+const trimRepeatedReservedChars = string => string.replace(reRepeatedReservedChars, '$1');

--- a/filenamify.js
+++ b/filenamify.js
@@ -3,12 +3,13 @@ import filenameReservedRegex, {windowsReservedNameRegex} from 'filename-reserved
 // Doesn't make sense to have longer filenames
 const MAX_FILENAME_LENGTH = 100;
 
-const reRepeatedReservedChars = /([<>:"/\\|?*\u0000-\u001F]){2,}/g; // eslint-disable-line no-control-regex
-const reControlChars = /[\u0000-\u001F\u0080-\u009F]/g; // eslint-disable-line no-control-regex
 const reRelativePath = /^\.+(\\|\/)|^\.+$/;
 const reTrailingPeriods = /\.+$/;
 
 export default function filenamify(string, options = {}) {
+	const reControlChars = /[\u0000-\u001F\u0080-\u009F]/g; // eslint-disable-line no-control-regex
+	const reRepeatedReservedCharacters = /([<>:"/\\|?*\u0000-\u001F]){2,}/g; // eslint-disable-line no-control-regex
+
 	if (typeof string !== 'string') {
 		throw new TypeError('Expected a string');
 	}
@@ -20,7 +21,7 @@ export default function filenamify(string, options = {}) {
 	}
 
 	if (replacement.length > 0) {
-		string = trimRepeatedReservedChars(string);
+		string = string.replace(reRepeatedReservedCharacters, '$1');
 	}
 
 	string = string.normalize('NFD');
@@ -58,5 +59,3 @@ export default function filenamify(string, options = {}) {
 
 	return string;
 }
-
-const trimRepeatedReservedChars = string => string.replace(reRepeatedReservedChars, '$1');

--- a/package.json
+++ b/package.json
@@ -43,9 +43,7 @@
 		"dirname"
 	],
 	"dependencies": {
-		"filename-reserved-regex": "^3.0.0",
-		"strip-outer": "^2.0.0",
-		"trim-repeated": "^2.0.0"
+		"filename-reserved-regex": "^3.0.0"
 	},
 	"devDependencies": {
 		"ava": "^3.15.0",

--- a/readme.md
+++ b/readme.md
@@ -16,10 +16,10 @@ npm install filenamify
 import filenamify from 'filenamify';
 
 filenamify('<foo/bar>');
-//=> 'foo!bar'
+//=> '!foo!bar!'
 
 filenamify('foo:"bar"', {replacement: '🐴'});
-//=> 'foo🐴bar'
+//=> 'foo🐴bar🐴'
 ```
 
 ## API
@@ -71,7 +71,7 @@ You can also import `filenamify/browser`, which only imports `filenamify` and no
 import filenamify from 'filenamify/browser';
 
 filenamify('<foo/bar>');
-//=> 'foo!bar'
+//=> '!foo!bar!'
 ```
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -8,10 +8,10 @@ const directoryName = path.dirname(fileURLToPath(import.meta.url));
 test('filenamify()', t => {
 	t.is(filenamify('foo/bar'), 'foo!bar');
 	t.is(filenamify('foo//bar'), 'foo!bar');
-	t.is(filenamify('//foo//bar//'), 'foo!bar');
+	t.is(filenamify('//foo//bar//'), '!foo!bar!');
 	t.is(filenamify('foo\\\\\\bar'), 'foo!bar');
 	t.is(filenamify('foo/bar', {replacement: '🐴🐴'}), 'foo🐴🐴bar');
-	t.is(filenamify('////foo////bar////', {replacement: '(('}), 'foo((bar');
+	t.is(filenamify('////foo////bar////', {replacement: '(('}), '((foo((bar((');
 	t.is(filenamify('foo\u0000bar'), 'foo!bar');
 	t.is(filenamify('.'), '!');
 	t.is(filenamify('..'), '!');
@@ -28,6 +28,11 @@ test('filenamify()', t => {
 	t.is(filenamify('c/n', {replacement: 'o'}), 'cono');
 	t.is(filenamify('c/n', {replacement: 'con'}), 'cconn');
 	t.is(filenamify('.dotfile'), '.dotfile');
+	t.is(filenamify('my <file name-', {replacement: '-'}), 'my -file name-');
+	t.is(filenamify('--<abc->>>--', {replacement: '-'}), '---abc----');
+	t.is(filenamify('-<<abc>-', {replacement: '-'}), '--abc--');
+	t.is(filenamify('my <file name<', {replacement: '-'}), 'my -file name-');
+	t.is(filenamify('my <file name<'), 'my !file name!');
 });
 
 test('filenamifyPath()', t => {


### PR DESCRIPTION
Fixes #11. Just like #12, "now we trim repeat and outer reserved chars before doing a global replace with the replacement char, to preserve instances of that char present in the original string".
The only difference is that I think we should maintain as much of the original string as possible, so we don't strip outer reserved characters, we only replace them with the replacement string.